### PR TITLE
fix bug of not parsing port and dbhost in config.json

### DIFF
--- a/src/init/AppRunner.ts
+++ b/src/init/AppRunner.ts
@@ -114,7 +114,7 @@ export class AppRunner {
                 baseUrl: { type: 'string', alias: 'b', requiresArg: true },
                 config: { type: 'string', alias: 'c', requiresArg: true },
                 loggingLevel: { type: 'string', alias: 'l', default: 'info', requiresArg: true },
-                port: { type: 'number', alias: 'p', default: 3000, requiresArg: true }
+                port: { type: 'number', alias: 'p', requiresArg: true }
             })
             .parseSync();
 

--- a/src/models/DatabaseFactory.ts
+++ b/src/models/DatabaseFactory.ts
@@ -6,8 +6,8 @@ export class DatabaseFactory {
     constructor(host: string) {
         this.db = new Sequelize({
             dialect: 'sqlite',
-            //storage: host
-            storage: ':memory:'
+            storage: host
+            // storage: ':memory:'
             //storage: 'path/to/database.sqlite'
         });
     }


### PR DESCRIPTION
Currently, there are two minor bugs, one is not able to parse the "port" in `config.json`, and the other is not able to parse "db" in `config.json`. 

The first bug is caused by setting a default value of variable `variableParams.port` to 3000 before parsing the config file: line 117 of `src/init/AppRunner.ts`. The default serves cli usage. Considering that all options can be set in the config file, and the cli options are of little usage, my solution is to remove the default value of the cli option. 

The second bug is simpler. In line 10 of file `src/model/DatabaseFactory.ts`, the storage choice is hard-coded to be ":memory:". My solution is to comment this line, and uncomment line 9, which introduce a variable `host`. To use ":memory:" as storage, users can just set the option in the config file: `{ "db": ":memory:" }`.
